### PR TITLE
Add zone-based pricing and auto refunds

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -1,13 +1,11 @@
-// Placeholder for database connectivity
-// In a real deployment, replace these with API calls or DB client logic
+// Temporary DB implementation using localStorage
+// In real deployment this should be replaced with actual API calls or DB logic
 export async function fetchFromDB(key) {
-  // TODO: implement actual DB retrieval
   const data = localStorage.getItem(key);
   return data ? JSON.parse(data) : null;
 }
 
 export async function saveToDB(key, value) {
-  // TODO: implement actual DB save
   localStorage.setItem(key, JSON.stringify(value));
 }
 


### PR DESCRIPTION
## Summary
- implement localStorage based temporary DB
- show header DB controls only for admin or organizer
- rename spectator role UI to 一般使用者
- add zone capacities and prices for concerts
- enable zone selection and purchase tracking
- support automated refund within 3 days and zone-aware manual refund
- remove Line Pay account field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a83eb47848328af2841ba714b886e