### PR TITLE
Implement homepage carousel and auto refund

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -612,3 +612,76 @@ h2 {
 @media (max-width: 600px) {
   .carousel-slide img { height: 200px; }
 }
+
+/* 首頁全螢幕輪播樣式 */
+.full-bg-carousel {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 0;
+  background: #000;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+}
+.full-bg-carousel .carousel-slides {
+  width: 100vw;
+  height: 100vh;
+}
+.full-bg-carousel .carousel-slide {
+  min-width: 100vw;
+  min-height: 100vh;
+  display: none;
+  position: absolute;
+  top: 0; left: 0;
+}
+.full-bg-carousel .carousel-slide.active {
+  display: block;
+}
+.full-bg-carousel .carousel-slide img {
+  width: 100vw;
+  height: 100vh;
+  object-fit: cover;
+  border-radius: 0;
+}
+.full-bg-carousel .slide-info {
+  position: absolute;
+  left: 0; right: 0; bottom: 80px;
+  background: rgba(0,0,0,0.45);
+  color: #fff;
+  padding: 2rem 1rem 1.5rem 1rem;
+  text-align: center;
+  font-size: 1.5rem;
+  backdrop-filter: blur(6px);
+}
+.overlay-login-btn {
+  position: absolute;
+  left: 50%;
+  bottom: 30px;
+  transform: translateX(-50%);
+  z-index: 10;
+  font-size: 1.3rem;
+  padding: 0.9rem 2.5rem;
+  background: var(--primary-color);
+  border-radius: 2rem;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.18);
+  border: none;
+  color: #fff;
+  transition: background 0.3s;
+}
+.overlay-login-btn:hover {
+  background: var(--accent-color);
+}
+body, #app, main, .home-carousel {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+#app {
+  min-height: 0 !important;
+  box-shadow: none !important;
+}
+main#mainContent {
+  padding: 0 !important;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -572,3 +572,43 @@ h2 {
 
 
 /* Modal Styles */
+.home-carousel {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--border-radius);
+}
+.carousel-slides {
+  display: flex;
+  width: 100%;
+}
+.carousel-slide {
+  min-width: 100%;
+  position: relative;
+  display: none;
+}
+.carousel-slide.active {
+  display: block;
+}
+.carousel-slide img {
+  width: 100%;
+  height: 300px;
+  object-fit: cover;
+  border-radius: var(--border-radius);
+}
+.slide-info {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background: rgba(0,0,0,0.4);
+  color: #fff;
+  backdrop-filter: blur(5px);
+}
+.home-login-btn {
+  margin-top: 1rem;
+  width: 100%;
+}
+@media (max-width: 600px) {
+  .carousel-slide img { height: 200px; }
+}

--- a/js/app.js
+++ b/js/app.js
@@ -106,11 +106,11 @@ function renderHomePage() {
   }).join('');
 
   mainContent.innerHTML = `
-    <div class="home-carousel">
+    <div class="home-carousel full-bg-carousel">
       <div class="carousel-slides" id="carouselSlides">
         ${carouselSlides}
       </div>
-      <button id="homeLoginBtn" class="home-login-btn">立即登入</button>
+      <button id="homeLoginBtn" class="home-login-btn overlay-login-btn">立即登入</button>
     </div>
   `;
 

--- a/js/app.js
+++ b/js/app.js
@@ -84,6 +84,50 @@ function clearLoginState() {
 
 // function roleNameDisplay(role){ ... moved to ui.js ... }
 
+// Render public home page with concert carousel
+function renderHomePage() {
+  logoutBtn.style.display = 'none';
+  switchRoleBtn.style.display = 'none';
+  accountSettingsBtn.style.display = 'none';
+
+  const carouselSlides = concerts.map(c => {
+    const venue = venues.find(v => v.id === c.venueId);
+    const firstSession = c.sessions && c.sessions[0];
+    const dateStr = firstSession ? new Date(firstSession.dateTime).toLocaleDateString() : '';
+    const location = venue ? venue.name : '';
+    return `
+      <div class="carousel-slide">
+        <img src="${c.imageUrl}" alt="${c.title}">
+        <div class="slide-info">
+          <h3>${c.title}</h3>
+          <p>${dateStr} ${location}</p>
+        </div>
+      </div>`;
+  }).join('');
+
+  mainContent.innerHTML = `
+    <div class="home-carousel">
+      <div class="carousel-slides" id="carouselSlides">
+        ${carouselSlides}
+      </div>
+      <button id="homeLoginBtn" class="home-login-btn">立即登入</button>
+    </div>
+  `;
+
+  const slides = Array.from(document.querySelectorAll('.carousel-slide'));
+  let slideIndex = 0;
+  if (slides.length) {
+    slides[0].classList.add('active');
+    setInterval(() => {
+      slides[slideIndex].classList.remove('active');
+      slideIndex = (slideIndex + 1) % slides.length;
+      slides[slideIndex].classList.add('active');
+    }, 4000);
+  }
+
+  document.getElementById('homeLoginBtn').onclick = () => authRenderLogin();
+}
+
 // Render dashboard based on role
 function renderDashboard() {
   if(!currentUser || !currentRole){
@@ -257,6 +301,10 @@ function renderDashboard() {
       // Corrected call to initPaymentModule:
       initPaymentModule(appData, saveData, getCurrentUser);
 
-      renderDashboard(); // Initial render
-      updateLoginRelatedUI(); // Update UI elements based on initial login state
+      if (currentUser && currentRole) {
+        renderDashboard();
+        updateLoginRelatedUI();
+      } else {
+        renderHomePage();
+      }
     }


### PR DESCRIPTION
## Summary
- add a responsive carousel home page with login button
- show home page when no user is logged in
- implement automatic refund if requested within 3 minutes of purchase
- append supporting styles for carousel UI

## Testing
- `node -c js/app.js`
- `node -c js/refund.js`

------
https://chatgpt.com/codex/tasks/task_e_684f766c4b248328bf0bd70901db4a03