### PR TITLE
Add README and DB API hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# 演唱會售票系統
+
+此專案為一個簡易的演唱會售票網站，採用純 HTML、CSS 與 JavaScript 開發。資料預設存放在瀏覽器的 `localStorage` 中，所有模組均放置於 `js` 目錄並以 ES modules 載入。
+
+## 快速接入資料庫
+
+`js/db.js` 提供了基本的 API 介面，會嘗試透過 `/api` 路徑向後端讀寫資料；若請求失敗，則退回使用 `localStorage`。因此，只要在後端實作以下路由即可串接真實的資料庫：
+
+```bash
+GET  /api/data/<key>
+POST /api/data/<key>
+```
+
+路由實作可使用 Express 搭配 MongoDB 或其他框架。由於前端的資料存取都集中在 `fetchFromDB` 與 `saveToDB` 兩個函式，故無需大幅修改即可切換至資料庫。
+
+## 開發方式
+
+直接以瀏覽器開啟 `index.html` 即可。主要進入點為 `js/main.js`，會在 `DOMContentLoaded` 事件觸發後啟動，能更快載入頁面。
+
+## 可能的優化
+
+- 架設簡易後端 (如 Express) 儲存資料。
+- 視專案規模拆分較大的資料檔，方便維護。
+- 上線前建議壓縮 CSS 與 JavaScript 檔案，提高效能。

--- a/js/db.js
+++ b/js/db.js
@@ -1,12 +1,29 @@
-// Placeholder for database connectivity
-// In a real deployment, replace these with API calls or DB client logic
+// Simple API wrapper to replace the previous localStorage-only approach.
+// By default it falls back to localStorage so existing code continues to work.
+const API_BASE = '/api';
+
 export async function fetchFromDB(key) {
-  // TODO: implement actual DB retrieval
-  const data = localStorage.getItem(key);
-  return data ? JSON.parse(data) : null;
+  try {
+    const resp = await fetch(`${API_BASE}/data/${key}`);
+    if (!resp.ok) throw new Error('Network response was not ok');
+    return await resp.json();
+  } catch (err) {
+    const data = localStorage.getItem(key);
+    return data ? JSON.parse(data) : null;
+  }
 }
 
 export async function saveToDB(key, value) {
-  // TODO: implement actual DB save
-  localStorage.setItem(key, JSON.stringify(value));
+  try {
+    const resp = await fetch(`${API_BASE}/data/${key}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(value),
+    });
+    if (!resp.ok) throw new Error('Network response was not ok');
+  } catch (err) {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -1,2 +1,4 @@
 import { initApp } from './app.js';
-window.addEventListener('load', initApp);
+// Use DOMContentLoaded to start the app sooner without waiting for all assets
+// to finish loading.
+window.addEventListener('DOMContentLoaded', initApp);


### PR DESCRIPTION
## Summary
- document quick DB integration and project usage
- make DB helpers call `/api` endpoints with localStorage fallback
- initialize app on DOMContentLoaded instead of waiting for images
- rewrite README in Chinese with DB guide

## Testing
- `git log -1 --stat`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68520a113928832892de90650db60dcf